### PR TITLE
Add pyproject.toml to make package installable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# HandRefinerPortable
+
+This is a convenience package used by
+[sd-webui-controlnet](https://github.com/Mikubill/sd-webui-controlnet)
+to package the dependencies and model used by the hand refiner preprocessor.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "handrefinerportable"
+readme = "README.md"
+version = "2024.01.18.0"
+dependencies = [
+    "rtree",
+    "mediapipe",
+    "trimesh[easy]",
+]
+
+[project.urls]
+Documentation = "https://github.com/huchenlei/HandRefinerPortable"
+Issues = "https://github.com/huchenlei/HandRefinerPortable/issues"
+Source = "https://github.com/huchenlei/HandRefinerPortable"
+
+[tool.hatch.build.targets.wheel]
+packages = [
+    "hand_refiner",
+    "manopth",
+    "mesh_graphormer",
+]


### PR DESCRIPTION
The package is a little unorthodox in that it installs three Python packages, none of which is named `handrefinerportable`.

IOW, installing this package will then overwrite `handrefiner`, `manopth` and `mesh_graphormer` if they're already in site-packages, but given the scope of this repository, that's probably acceptable for now.

Changing that would require changing import paths, etc. within the code too, but could be done later.